### PR TITLE
Removed rstrip() for proper line blanking

### DIFF
--- a/asciichartpy/__init__.py
+++ b/asciichartpy/__init__.py
@@ -173,4 +173,4 @@ def plot(series, cfg=None):
             for y in range(start, end):
                 result[rows - y][x + offset] = symbols[9]
 
-    return '\n'.join([''.join(row).rstrip() for row in result])
+    return '\n'.join([''.join(row) for row in result])


### PR DESCRIPTION
The addition of `.rstrip()` to the return output broke line blanking when overwriting the same screen space; removed it to restore previous behavior.